### PR TITLE
Manipulating genres of playlist

### DIFF
--- a/src/main/java/br/com/apollomusic/app/Spotify/Dto/Playlist/ObjectUri.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/Dto/Playlist/ObjectUri.java
@@ -1,4 +1,0 @@
-package br.com.apollomusic.app.Spotify.Dto.Playlist;
-
-public record ObjectUri(String uri) {
-}

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Genre/AvailableGenresDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Genre/AvailableGenresDto.java
@@ -1,0 +1,6 @@
+package br.com.apollomusic.app.Spotify.dto.Genre;
+
+import java.util.Set;
+
+public record AvailableGenresDto(Set<String> genres) {
+}

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Me/UserSpotifyDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Me/UserSpotifyDto.java
@@ -1,4 +1,4 @@
-package br.com.apollomusic.app.Spotify.Dto.Me;
+package br.com.apollomusic.app.Spotify.dto.Me;
 
 public record UserSpotifyDto(String display_name, String id) {
 }

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/AddItemToPlaylistReqDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/AddItemToPlaylistReqDto.java
@@ -1,4 +1,4 @@
-package br.com.apollomusic.app.Spotify.Dto.Playlist;
+package br.com.apollomusic.app.Spotify.dto.Playlist;
 
 import java.util.Set;
 

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/AddItemToPlaylistResDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/AddItemToPlaylistResDto.java
@@ -1,4 +1,4 @@
-package br.com.apollomusic.app.Spotify.Dto.Playlist;
+package br.com.apollomusic.app.Spotify.dto.Playlist;
 
 public record AddItemToPlaylistResDto(String snapshot_id) {
 }

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/NewPlaylistSpotifyDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/NewPlaylistSpotifyDto.java
@@ -1,4 +1,4 @@
-package br.com.apollomusic.app.Spotify.Dto.Playlist;
+package br.com.apollomusic.app.Spotify.dto.Playlist;
 
 public  record NewPlaylistSpotifyDto(String name, String description){
 }

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/NewPlaylistSpotifyResDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/NewPlaylistSpotifyResDto.java
@@ -1,4 +1,4 @@
-package br.com.apollomusic.app.Spotify.Dto.Playlist;
+package br.com.apollomusic.app.Spotify.dto.Playlist;
 
 public record NewPlaylistSpotifyResDto(String id, String snapshot_id) {
 }

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/ObjectUri.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/ObjectUri.java
@@ -1,0 +1,4 @@
+package br.com.apollomusic.app.Spotify.dto.Playlist;
+
+public record ObjectUri(String uri) {
+}

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/RemoveItemFromPlaylistReqDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/RemoveItemFromPlaylistReqDto.java
@@ -1,4 +1,4 @@
-package br.com.apollomusic.app.Spotify.Dto.Playlist;
+package br.com.apollomusic.app.Spotify.dto.Playlist;
 
 import java.util.Set;
 

--- a/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/RemoveItemFromPlaylistResDto.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/dto/Playlist/RemoveItemFromPlaylistResDto.java
@@ -1,4 +1,4 @@
-package br.com.apollomusic.app.Spotify.Dto.Playlist;
+package br.com.apollomusic.app.Spotify.dto.Playlist;
 
 public record RemoveItemFromPlaylistResDto(String snapshot_id) {
 }

--- a/src/main/java/br/com/apollomusic/app/Spotify/services/GenreSpotifyService.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/services/GenreSpotifyService.java
@@ -1,0 +1,26 @@
+package br.com.apollomusic.app.Spotify.services;
+
+import br.com.apollomusic.app.Spotify.dto.Genre.AvailableGenresDto;
+import br.com.apollomusic.app.model.services.ApiService;
+import com.google.gson.Gson;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+
+@Service
+public class GenreSpotifyService {
+
+    private final ApiService apiService;
+    private final Gson gson;
+
+    public GenreSpotifyService(ApiService apiService, Gson gson) {
+        this.apiService = apiService;
+        this.gson = gson;
+    }
+
+    public AvailableGenresDto getAvailableGenres(String spotifyAccessToken){
+        String response = apiService.get("/recommendations/available-genre-seeds", new HashMap<>(), spotifyAccessToken);
+        return gson.fromJson(response, AvailableGenresDto.class);
+    }
+
+}

--- a/src/main/java/br/com/apollomusic/app/Spotify/services/PlaylistSpotifyService.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/services/PlaylistSpotifyService.java
@@ -1,6 +1,6 @@
-package br.com.apollomusic.app.Spotify.Services;
+package br.com.apollomusic.app.Spotify.services;
 
-import br.com.apollomusic.app.Spotify.Dto.Playlist.*;
+import br.com.apollomusic.app.Spotify.dto.Playlist.*;
 import br.com.apollomusic.app.model.services.ApiService;
 import com.google.gson.Gson;
 import org.springframework.stereotype.Service;

--- a/src/main/java/br/com/apollomusic/app/Spotify/services/UserSpotifyService.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/services/UserSpotifyService.java
@@ -1,6 +1,6 @@
-package br.com.apollomusic.app.Spotify.Services;
+package br.com.apollomusic.app.Spotify.services;
 
-import br.com.apollomusic.app.Spotify.Dto.Me.UserSpotifyDto;
+import br.com.apollomusic.app.Spotify.dto.Me.UserSpotifyDto;
 import br.com.apollomusic.app.model.services.ApiService;
 import com.google.gson.Gson;
 import org.springframework.stereotype.Service;
@@ -20,8 +20,7 @@ public class UserSpotifyService {
     }
 
     public UserSpotifyDto getUserOnSpotify(String spotifyAccessToken){
-        Map<String, String> queryParams = new HashMap<>();
-        String me = apiService.get("me", queryParams, spotifyAccessToken);
+        String me = apiService.get("me", new HashMap<>(), spotifyAccessToken);
         return gson.fromJson(me, UserSpotifyDto.class);
     }
 }

--- a/src/main/java/br/com/apollomusic/app/Spotify/utils/GenerateDefaultInformation.java
+++ b/src/main/java/br/com/apollomusic/app/Spotify/utils/GenerateDefaultInformation.java
@@ -1,7 +1,6 @@
 package br.com.apollomusic.app.Spotify.utils;
 
-import br.com.apollomusic.app.Spotify.Dto.Playlist.NewPlaylistSpotifyDto;
-import org.springframework.stereotype.Service;
+import br.com.apollomusic.app.Spotify.dto.Playlist.NewPlaylistSpotifyDto;
 
 public class GenerateDefaultInformation {
     public GenerateDefaultInformation() {}

--- a/src/main/java/br/com/apollomusic/app/controller/AuthController.java
+++ b/src/main/java/br/com/apollomusic/app/controller/AuthController.java
@@ -1,5 +1,6 @@
 package br.com.apollomusic.app.controller;
 
+import br.com.apollomusic.app.model.dto.LogoutUserDto;
 import br.com.apollomusic.app.model.dto.OwnerApiAuthReqDto;
 import br.com.apollomusic.app.model.dto.OwnerReqDto;
 import br.com.apollomusic.app.model.dto.UserReqDto;
@@ -28,6 +29,11 @@ public class AuthController {
     @PostMapping("/owner")
     public ResponseEntity<?> loginOwner(@RequestBody OwnerReqDto ownerReqDto) {
         return authService.loginOwner(ownerReqDto);
+    }
+
+    @DeleteMapping("/user")
+    public ResponseEntity<?> logoutUser(@RequestBody LogoutUserDto logoutUserDto) {
+        return  authService.logoutUser(logoutUserDto);
     }
 
     @PostMapping("/api")

--- a/src/main/java/br/com/apollomusic/app/controller/EstablishmentController.java
+++ b/src/main/java/br/com/apollomusic/app/controller/EstablishmentController.java
@@ -30,23 +30,29 @@ public class EstablishmentController {
     @PostMapping("/playlist")
     @PreAuthorize("hasAuthority('SCOPE_ROLE_ADMIN')")
     public ResponseEntity<?> createPlaylist(@PathVariable long establishmentId, @RequestBody NewPlaylistDto newPlaylistDto){
-        return establishmentService.createPlaylistOnSpotify(establishmentId, newPlaylistDto);
+        return establishmentService.createPlaylist(establishmentId, newPlaylistDto);
     }
 
     @PostMapping("/playlist/genres/block")
     @PreAuthorize("hasAuthority('SCOPE_ROLE_ADMIN')")
-    public ResponseEntity<?> blockGenres(@PathVariable long establishmentId, @RequestBody GenreDto genreDto){
-        return establishmentService.blockGenres(establishmentId, genreDto.genres());
+    public ResponseEntity<?> addBlockGenres(@PathVariable long establishmentId, @RequestBody GenreDto genreDto){
+        return establishmentService.addBlockGenres(establishmentId, genreDto.genres());
+    }
+
+    @DeleteMapping("/playlist/genres/block")
+    @PreAuthorize("hasAuthority('SCOPE_ROLE_ADMIN')")
+    public ResponseEntity<?> removeBlockGenres(@PathVariable long establishmentId, @RequestBody GenreDto genreDto){
+        return establishmentService.removeBlockGenres(establishmentId, genreDto.genres());
     }
 
     @PostMapping("/playlist/genres/increment")
-//    @PreAuthorize("hasAuthority('SCOPE_ROLE_ADMIN')") we need add both of roles here
+    @PreAuthorize("hasAnyAuthority('SCOPE_ROLE_ADMIN', 'SCOPE_ROLE_USER')")
     public ResponseEntity<?> incrementVoteGenres(@PathVariable long establishmentId, @RequestBody GenreDto genreDto){
         return establishmentService.incrementVoteGenres(establishmentId, genreDto.genres());
     }
 
     @PostMapping("/playlist/genres/decrement")
-//    @PreAuthorize("hasAuthority('SCOPE_ROLE_ADMIN')") we need add both of roles here
+    @PreAuthorize("hasAnyAuthority('SCOPE_ROLE_ADMIN', 'SCOPE_ROLE_USER')")
     public ResponseEntity<?> decrementVoteGenres(@PathVariable long establishmentId, @RequestBody GenreDto genreDto){
         return establishmentService.decrementVoteGenres(establishmentId, genreDto.genres());
     }

--- a/src/main/java/br/com/apollomusic/app/model/dto/LogoutUserDto.java
+++ b/src/main/java/br/com/apollomusic/app/model/dto/LogoutUserDto.java
@@ -1,0 +1,4 @@
+package br.com.apollomusic.app.model.dto;
+
+public record LogoutUserDto(Long userId, Long establishmentId) {
+}

--- a/src/main/java/br/com/apollomusic/app/model/dto/RemoveSongsFromPlaylistReqDto.java
+++ b/src/main/java/br/com/apollomusic/app/model/dto/RemoveSongsFromPlaylistReqDto.java
@@ -1,6 +1,5 @@
 package br.com.apollomusic.app.model.dto;
 
-import br.com.apollomusic.app.Spotify.Dto.Playlist.ObjectUri;
 import br.com.apollomusic.app.model.entities.Song;
 
 import java.util.Set;

--- a/src/main/java/br/com/apollomusic/app/model/dto/UserReqDto.java
+++ b/src/main/java/br/com/apollomusic/app/model/dto/UserReqDto.java
@@ -1,6 +1,6 @@
 package br.com.apollomusic.app.model.dto;
 
-import java.util.List;
+import java.util.Set;
 
-public record UserReqDto(String username, List<String> genres, Long establishmentId) {
+public record UserReqDto(String username, Set<String> genres, Long establishmentId) {
 }

--- a/src/main/java/br/com/apollomusic/app/model/entities/Playlist.java
+++ b/src/main/java/br/com/apollomusic/app/model/entities/Playlist.java
@@ -112,14 +112,20 @@ public class Playlist {
         songs.removeIf(s -> s.getUri().equals(song.getUri()));
     }
 
+    public void addBlockGenres(Set<String> blockedGenres){
+        this.blockedGenres.addAll(blockedGenres);
+        removeGenres(blockedGenres);
+    }
+
+    public void removeBlockGenres(Set<String> blockedGenres){
+        this.blockedGenres.removeAll(blockedGenres);
+        addGenres(blockedGenres);
+    }
+
     public void incrementVoteGenre(Set<String> genres){
         for(String genre: genres){
-            if(!this.blockedGenres.contains(genre)){
-                if(this.genres.containsKey(genre)){
-                    this.genres.put(genre, this.genres.get(genre) + 1);
-                }else{
-                    this.genres.put(genre, 1);
-                }
+            if(this.genres.containsKey(genre)){
+                this.genres.put(genre, this.genres.get(genre) + 1);
             }
         }
     }
@@ -129,12 +135,22 @@ public class Playlist {
             if(this.genres.containsKey(genre)){
                 if(this.genres.get(genre) > 0){
                     this.genres.put(genre, this.genres.get(genre) - 1);
-                }else{
-                    this.genres.remove(genre);
                 }
-
             }
         }
     }
+
+    private void removeGenres(Set<String> genres){
+        for(String genre : genres){
+            this.genres.remove(genre);
+        }
+    }
+
+    private void addGenres(Set<String> genres){
+        for(String genre : genres){
+            this.genres.put(genre, 1);
+        }
+    }
+
 
 }

--- a/src/main/java/br/com/apollomusic/app/model/services/AuthService.java
+++ b/src/main/java/br/com/apollomusic/app/model/services/AuthService.java
@@ -31,15 +31,17 @@ public class AuthService {
     private final JwtUtil jwtUtil;
     private final OwnerRepository ownerRepository;
     private final PasswordEncoder passwordEncoder;
+    private final PlaylistService playlistService;
 
     @Autowired
-    public AuthService(UserRepository userRepository, EstablishmentRepository establishmentRepository, JwtUtil jwtUtil, RoleRepository roleRepository, OwnerRepository ownerRepository, PasswordEncoder passwordEncoder) {
+    public AuthService(UserRepository userRepository, EstablishmentRepository establishmentRepository, JwtUtil jwtUtil, RoleRepository roleRepository, OwnerRepository ownerRepository, PasswordEncoder passwordEncoder, PlaylistService playlistService) {
         this.userRepository = userRepository;
         this.establishmentRepository = establishmentRepository;
         this.jwtUtil = jwtUtil;
         this.roleRepository = roleRepository;
         this.ownerRepository = ownerRepository;
         this.passwordEncoder = passwordEncoder;
+        this.playlistService = playlistService;
     }
 
     public ResponseEntity<?> loginUser(UserReqDto userReqDto) {
@@ -51,6 +53,8 @@ public class AuthService {
 
             User user = new User(establishment, userReqDto.username(), new HashSet<>(userReqDto.genres()), Set.of(userRole));
             userRepository.save(user);
+
+            playlistService.incrementVoteGenres(establishment.getPlaylist().getPlaylistId(), userReqDto.genres());
 
             String token = jwtUtil.createTokenUser(user);
             return ResponseEntity.ok().body(new UserResDto(user.getUserName(), token));

--- a/src/main/java/br/com/apollomusic/app/model/services/EstablishmentService.java
+++ b/src/main/java/br/com/apollomusic/app/model/services/EstablishmentService.java
@@ -1,10 +1,10 @@
 package br.com.apollomusic.app.model.services;
 
-import br.com.apollomusic.app.Spotify.Dto.Me.UserSpotifyDto;
-import br.com.apollomusic.app.Spotify.Dto.Playlist.NewPlaylistSpotifyDto;
-import br.com.apollomusic.app.Spotify.Dto.Playlist.NewPlaylistSpotifyResDto;
-import br.com.apollomusic.app.Spotify.Services.PlaylistSpotifyService;
-import br.com.apollomusic.app.Spotify.Services.UserSpotifyService;
+import br.com.apollomusic.app.Spotify.dto.Me.UserSpotifyDto;
+import br.com.apollomusic.app.Spotify.dto.Playlist.NewPlaylistSpotifyDto;
+import br.com.apollomusic.app.Spotify.dto.Playlist.NewPlaylistSpotifyResDto;
+import br.com.apollomusic.app.Spotify.services.PlaylistSpotifyService;
+import br.com.apollomusic.app.Spotify.services.UserSpotifyService;
 import br.com.apollomusic.app.Spotify.utils.GenerateDefaultInformation;
 import br.com.apollomusic.app.model.dto.ErrorResDto;
 import br.com.apollomusic.app.model.dto.NewPlaylistDto;
@@ -22,35 +22,22 @@ import java.util.*;
 public class EstablishmentService {
 
     private final EstablishmentRepository establishmentRepository;
-    private final PlaylistRepository playlistRepository;
-    private final UserSpotifyService userSpotifyService;
-    private final PlaylistSpotifyService playlistSpotifyService;
     private final PlaylistService playlistService;
 
-    public EstablishmentService(EstablishmentRepository establishmentRepository, PlaylistRepository playlistRepository, UserSpotifyService userSpotifyService, PlaylistSpotifyService playlistSpotifyService, PlaylistService playlistService) {
+    public EstablishmentService(EstablishmentRepository establishmentRepository, PlaylistService playlistService) {
         this.establishmentRepository = establishmentRepository;
-        this.playlistRepository = playlistRepository;
-        this.userSpotifyService = userSpotifyService;
-        this.playlistSpotifyService = playlistSpotifyService;
         this.playlistService = playlistService;
     }
 
-    public ResponseEntity<?> createPlaylistOnSpotify(long id, NewPlaylistDto newPlaylistDto){
+    public ResponseEntity<?> createPlaylist(long establishmentId, NewPlaylistDto newPlaylistDto){
         try {
-            Establishment establishment = establishmentRepository.findById(id).get();
+            Establishment establishment = establishmentRepository.findById(establishmentId).get();
             if(establishment.getEstablishmentId() == null){
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(new ErrorResDto(HttpStatus.NOT_FOUND.value(), "Estabelecimento não encontrado"));
             }
-            NewPlaylistSpotifyDto newPlaylistSpotifyDto = GenerateDefaultInformation.generateDefaultPlaylist(establishment.getName());
-            UserSpotifyDto userSpotifyDto = userSpotifyService.getUserOnSpotify(newPlaylistDto.spotifyAccessToken());
-            NewPlaylistSpotifyResDto newPlaylistSpotifyResDto = playlistSpotifyService.createPlaylist(userSpotifyDto.id(), newPlaylistSpotifyDto, newPlaylistDto.spotifyAccessToken());
 
-            Playlist playlist = new Playlist(newPlaylistSpotifyResDto.id(), establishment, new HashSet<>(), new HashSet<>(), new HashMap<>(), newPlaylistSpotifyResDto.snapshot_id());
-            playlistRepository.save(playlist);
-            establishmentRepository.setPlaylistEstablishment(id, playlist);
-
-            return ResponseEntity.ok().body("Playlist criada com sucesso: " + newPlaylistSpotifyResDto.id());
+            return playlistService.createPlaylist(establishmentId, newPlaylistDto);
         }catch (Exception e){
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new ErrorResDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Erro interno no servidor"));
@@ -94,7 +81,7 @@ public class EstablishmentService {
         return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body("Erro ao desligar Estabelicimento");
     }
 
-    public ResponseEntity<?> blockGenres(long establishmentId, Set<String> genres){
+    public ResponseEntity<?> addBlockGenres(long establishmentId, Set<String> genres){
         try{
             Optional<Establishment> establishment = establishmentRepository.findById(establishmentId);
             if(establishment.isEmpty()){
@@ -102,7 +89,23 @@ public class EstablishmentService {
                         .body(new ErrorResDto(HttpStatus.NOT_FOUND.value(), "Estabelecimento não encontrado"));
             }
 
-            return playlistService.blockGenres(establishment.get().getPlaylist().getPlaylistId(), genres);
+            return playlistService.addBlockGenres(establishment.get().getPlaylist().getPlaylistId(), genres);
+
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Erro interno no servidor"));
+        }
+    }
+
+    public ResponseEntity<?> removeBlockGenres(long establishmentId, Set<String> genres){
+        try{
+            Optional<Establishment> establishment = establishmentRepository.findById(establishmentId);
+            if(establishment.isEmpty()){
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ErrorResDto(HttpStatus.NOT_FOUND.value(), "Estabelecimento não encontrado"));
+            }
+
+            return playlistService.removeBlockGenres(establishment.get().getPlaylist().getPlaylistId(), genres);
 
         }catch (Exception e){
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/br/com/apollomusic/app/model/services/PlaylistService.java
+++ b/src/main/java/br/com/apollomusic/app/model/services/PlaylistService.java
@@ -1,30 +1,71 @@
 package br.com.apollomusic.app.model.services;
 
-import br.com.apollomusic.app.Spotify.Dto.Playlist.*;
-import br.com.apollomusic.app.Spotify.Services.PlaylistSpotifyService;
+import br.com.apollomusic.app.Spotify.dto.Genre.AvailableGenresDto;
+import br.com.apollomusic.app.Spotify.dto.Me.UserSpotifyDto;
+import br.com.apollomusic.app.Spotify.dto.Playlist.*;
+import br.com.apollomusic.app.Spotify.services.GenreSpotifyService;
+import br.com.apollomusic.app.Spotify.services.PlaylistSpotifyService;
+import br.com.apollomusic.app.Spotify.services.UserSpotifyService;
+import br.com.apollomusic.app.Spotify.utils.GenerateDefaultInformation;
 import br.com.apollomusic.app.model.dto.ErrorResDto;
+import br.com.apollomusic.app.model.dto.NewPlaylistDto;
+import br.com.apollomusic.app.model.entities.Establishment;
 import br.com.apollomusic.app.model.entities.Playlist;
 import br.com.apollomusic.app.model.entities.Song;
+import br.com.apollomusic.app.repository.EstablishmentRepository;
 import br.com.apollomusic.app.repository.PlaylistRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 @Service
 public class PlaylistService {
 
     private final PlaylistRepository playlistRepository;
     private final PlaylistSpotifyService playlistSpotifyService;
+    private final UserSpotifyService userSpotifyService;
+    private final GenreSpotifyService genreSpotifyService;
+    private final EstablishmentRepository establishmentRepository;
 
     @Autowired
-    public PlaylistService (PlaylistRepository playlistRepository , PlaylistSpotifyService playlistSpotifyService){
+    public PlaylistService (PlaylistRepository playlistRepository , PlaylistSpotifyService playlistSpotifyService, EstablishmentRepository establishmentRepository, UserSpotifyService userSpotifyService, GenreSpotifyService genreSpotifyService){
         this.playlistRepository = playlistRepository;
         this.playlistSpotifyService = playlistSpotifyService;
+        this.establishmentRepository = establishmentRepository;
+        this.userSpotifyService = userSpotifyService;
+        this.genreSpotifyService = genreSpotifyService;
+    }
+
+    public ResponseEntity<?> createPlaylist(long establishmentId, NewPlaylistDto newPlaylistDto){
+        try {
+            Optional<Establishment> establishment = establishmentRepository.findById(establishmentId);
+            if(establishment.isEmpty()){
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ErrorResDto(HttpStatus.NOT_FOUND.value(), "Estabelecimento não encontrado"));
+            }
+
+            NewPlaylistSpotifyDto newPlaylistSpotifyDto = GenerateDefaultInformation.generateDefaultPlaylist(establishment.get().getName());
+            UserSpotifyDto userSpotifyDto = userSpotifyService.getUserOnSpotify(newPlaylistDto.spotifyAccessToken());
+            NewPlaylistSpotifyResDto newPlaylistSpotifyResDto = playlistSpotifyService.createPlaylist(userSpotifyDto.id(), newPlaylistSpotifyDto, newPlaylistDto.spotifyAccessToken());
+
+            AvailableGenresDto availableGenres = genreSpotifyService.getAvailableGenres(newPlaylistDto.spotifyAccessToken());
+            Map<String, Integer> genres = new HashMap<>();
+            for (String genre : availableGenres.genres()){
+                genres.put(genre, 0);
+            }
+            Playlist playlist = new Playlist(newPlaylistSpotifyResDto.id(), establishment.get(), new HashSet<>(), new HashSet<>(), genres, newPlaylistSpotifyResDto.snapshot_id());
+
+            playlistRepository.save(playlist);
+            establishmentRepository.setPlaylistEstablishment(establishmentId, playlist);
+
+            return ResponseEntity.ok().body(newPlaylistSpotifyResDto);
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Erro interno no servidor"));
+        }
     }
 
     public ResponseEntity<?> addSongsToPlaylist(String playlistId, Set<Song> songs, String spotifyAccessToken){
@@ -85,7 +126,7 @@ public class PlaylistService {
         }
     }
 
-    public ResponseEntity<?> blockGenres(String playlistId, Set<String> genres){
+    public ResponseEntity<?> addBlockGenres(String playlistId, Set<String> genres){
         try {
             Optional<Playlist> playlist = playlistRepository.findById(playlistId);
 
@@ -94,7 +135,26 @@ public class PlaylistService {
                         .body(new ErrorResDto(HttpStatus.NOT_FOUND.value(), "Playlist não encontrada"));
             }
 
-            playlistRepository.blockGenres(playlistId, genres);
+            playlistRepository.addBlockGenre(playlistId, genres);
+
+            return ResponseEntity.ok().body(genres);
+
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Erro interno no servidor"));
+        }
+    }
+
+    public ResponseEntity<?> removeBlockGenres(String playlistId, Set<String> genres){
+        try {
+            Optional<Playlist> playlist = playlistRepository.findById(playlistId);
+
+            if(playlist.isEmpty()){
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ErrorResDto(HttpStatus.NOT_FOUND.value(), "Playlist não encontrada"));
+            }
+
+            playlistRepository.removeBlockGenre(playlistId, genres);
 
             return ResponseEntity.ok().body(genres);
 

--- a/src/main/java/br/com/apollomusic/app/repository/PlaylistRepository.java
+++ b/src/main/java/br/com/apollomusic/app/repository/PlaylistRepository.java
@@ -2,6 +2,7 @@ package br.com.apollomusic.app.repository;
 
 import br.com.apollomusic.app.model.entities.Playlist;
 import br.com.apollomusic.app.model.entities.Song;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
@@ -51,6 +52,7 @@ public interface PlaylistRepository extends JpaRepository<Playlist, String> {
     }
 
     @Modifying
+    @Transactional
     default void incrementVoteGenres(String playlistId, Set<String> genres){
         Playlist playlist = findById(playlistId).orElseThrow();
         playlist.incrementVoteGenre(genres);
@@ -58,6 +60,7 @@ public interface PlaylistRepository extends JpaRepository<Playlist, String> {
     }
 
     @Modifying
+    @Transactional
     default void decrementVoteGenres(String playlistId, Set<String> genres){
         Playlist playlist = findById(playlistId).orElseThrow();
         playlist.decrementVoteGenre(genres);

--- a/src/main/java/br/com/apollomusic/app/repository/PlaylistRepository.java
+++ b/src/main/java/br/com/apollomusic/app/repository/PlaylistRepository.java
@@ -2,15 +2,10 @@ package br.com.apollomusic.app.repository;
 
 import br.com.apollomusic.app.model.entities.Playlist;
 import br.com.apollomusic.app.model.entities.Song;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Set;
 
 @Repository
@@ -42,9 +37,16 @@ public interface PlaylistRepository extends JpaRepository<Playlist, String> {
     }
 
     @Modifying
-    default void blockGenres(String playlistId, Set<String> genres){
+    default void addBlockGenre(String playlistId, Set<String> genres){
         Playlist playlist = findById(playlistId).orElseThrow();
-        playlist.setBlockedGenres(genres);
+        playlist.addBlockGenres(genres);
+        save(playlist);
+    }
+
+    @Modifying
+    default void removeBlockGenre(String playlistId, Set<String> genres){
+        Playlist playlist = findById(playlistId).orElseThrow();
+        playlist.removeBlockGenres(genres);
         save(playlist);
     }
 


### PR DESCRIPTION
**Changes:**

- When the User logs into the application, the selected genres are added to the playlist.
- When the User logs out of the application, the User is deleted from the database and their genres are removed from the playlist.
- When creating a playlist, it is populated with all available genres on Spotify.
- When blocking genres from a playlist, these genres are added to the blocked table and removed from the genres table.
- When unblocking genres from a playlist, these genres are removed from the blocked table and added with 0 votes to the genres table.